### PR TITLE
Awarding player experience for using items

### DIFF
--- a/Leveling/Leveling/src/Leveling/Awarders/UseItemPatches.cs
+++ b/Leveling/Leveling/src/Leveling/Awarders/UseItemPatches.cs
@@ -10,7 +10,11 @@ internal class UseItemPatches
 
     private static float CalculateExperience(Rarity itemRarity)
     {
-        float weight = LootData.RarityWeights[itemRarity];
+        float weight = 100;
+        if (LootData.RarityWeights.ContainsKey(itemRarity))
+        {
+            weight = LootData.RarityWeights[itemRarity];
+        }
 
         return 100 / weight * Mathf.Log10(weight);
     }


### PR DESCRIPTION
Player will be rewarded for using items based on their rarity using formula defined in `UseItemPatches.CalculateExperience`